### PR TITLE
fix: remove unused dependencies and security placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,9 @@
         "commander": "^2.20.0",
         "conventional-cli": "^1.2.0",
         "dir-glob": "^3.0.1",
-        "fs": "0.0.1-security",
         "glob": "^7.1.4",
         "lodash": "^4.17.20",
-        "ngast": "^0.6.2",
-        "path": "^0.12.7",
-        "rxjs": "^6.5.4",
-        "string-similarity": "^4.0.1",
-        "typescript": "^4.1.2"
+        "string-similarity": "^4.0.1"
     },
     "devDependencies": {
         "@semantic-release/changelog": "^3.0.2",

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -8,8 +8,6 @@ import { KeysUtils } from './utils';
 import { FileLanguageModel, FileViewModel, KeyModel, LanguagesModel, ResultCliModel, ResultErrorModel } from './models';
 import { AbsentViewKeysRule, MisprintRule, ZombieRule, EmptyKeysRule } from './rules';
 import { KeyModelWithLanguages, LanguagesModelWithKey, ViewModelWithKey } from './models/KeyModelWithLanguages';
-import { WorkspaceSymbols } from 'ngast';
-import { NgModuleSymbol } from 'ngast/lib/ngtsc/module.symbol';
 
 
 class ReactI18nextLint {


### PR DESCRIPTION
The package has some dependencies that are unused.

One of them, "ngast" has issues with peer dependencies when installing in other projects with typescript.